### PR TITLE
Bugfix for removing courses from the College Career tab

### DIFF
--- a/src/main/java/org/example/FXMLController.java
+++ b/src/main/java/org/example/FXMLController.java
@@ -344,6 +344,14 @@ public class FXMLController {
         LogHelper.logUserAction(new UserAction(cl,c,null, UserAction.actionType.REMOVE_COURSE));
     }
 
+    @FXML
+    public void onRemoveButtonClicked(Course c, CourseList cl, VBox vb) throws Exception {
+        cl.removeCourse(c);
+        displaySchedule(cl, vb);
+        updateTotalCredits();
+        LogHelper.logUserAction(new UserAction(cl,c,null, UserAction.actionType.REMOVE_COURSE));
+    }
+
     public void updateTotalCredits() {
         totalCreditsFall.setText("Total Credits: " + fallSemester.getTotalCredits());
         totalCreditsSpring.setText("Total Credits: " + springSemester.getTotalCredits());


### PR DESCRIPTION
This overloads the course remove method so that it uses the right display method